### PR TITLE
Use Mattermost v4 api when importing

### DIFF
--- a/bin/emojiporter
+++ b/bin/emojiporter
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
+require('babel-polyfill');
+require('isomorphic-fetch');
 const fs = require('fs');
 const prompt = require('prompt');
 const yargs = require('yargs');
-const Mattermost = require('mattermost');
+const Mattermost = require('mattermost-redux/client');
 
 const Const = require('../lib/helpers/const');
 const ActionList = Const.ActionList;
@@ -43,10 +45,6 @@ const schema = {
     properties: {
         url: {
             message: 'Mattermost Server URL',
-            required: true
-        },
-        teamId: {
-            message: 'Team ID (not team name)',
             required: true
         },
 
@@ -129,13 +127,11 @@ prompt.get(schema, (err, params) => {
     const password = params.password;
     const mfaToken = params.mfaToken || undefined;
 
-    const client = new Mattermost.Client();
+    const client = Mattermost.Client4;
     client.setUrl(url);
-    client.setTeamId(teamId);
-    client.useHeaderToken();
 
     if (!token) {
-        client.login(loginId, password, mfaToken,
+        client.login(loginId, password, mfaToken).then(
             (data, res) => {
                 console.log('Login success');
                 runAction(client, data.id, params);
@@ -144,8 +140,7 @@ prompt.get(schema, (err, params) => {
                 console.log('Login error:', err);
             });
     } else {
-        client.token = token;
-        client.useHeaderToken();
+        client.setToken(token);
         console.log('Running request with provided token and id');
         runAction(client, id, params);
     }

--- a/lib/actions/importEmoji.js
+++ b/lib/actions/importEmoji.js
@@ -7,19 +7,19 @@ const request = require('request');
 
 const loadYaml = require('../helpers/loadYaml');
 
-function addEmoji(client, creator_id, name, tmpFileName,
+function addEmoji(client, creator_id, name, stream,
   success, error) {
-  client.addEmoji({
+  client.createCustomEmoji({
       creator_id: creator_id,
       name: name
-  }, tmpFileName,
+  }, stream).then(
   (data) => {
       console.log(`Imported ${name}`);
-      success(data);
+      if (success) success(data);
   },
   (err) => {
       console.log(`Error importing ${name}`, err);
-      error(err);
+      if (error) error(err);
   });
 }
 
@@ -43,19 +43,11 @@ module.exports = (client, id, importFile) => {
 
           if (isUri(src)) {
             // Upload remote emoji image by downloading temp file
-            const tmpFileName = `__tmp__${name}`;
-            request(src)
-              .pipe(fs.createWriteStream(tmpFileName))
-              .on('close', () => {
-                addEmoji(client, creator_id, name, tmpFileName, () => {
-                  fs.unlink(tmpFileName);
-                }, () => {
-                  fs.unlink(tmpFileName);
-                });
-              });
+            const stream = request(src);
+            addEmoji(client, creator_id, name, stream);
           } else if (fs.existsSync(localSrc)) {
             // Upload local emoji image
-            addEmoji(client, creator_id, name, localSrc);
+            addEmoji(client, creator_id, name, fs.createReadStream(localSrc));
           } else {
             console.error(`Unable to process src for ${name}`);
           }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   },
   "preferGlobal": "true",
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.18.0",
+    "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.3.1",
-    "mattermost": "^3.4.0",
+    "mattermost-redux": "^1.2.0",
     "path": "^0.12.7",
     "prompt": "^1.0.0",
     "request": "^2.78.0",


### PR DESCRIPTION
Thanks so much for making this project! It made importing all the parrot party emoji to Mattermost a whole lot faster than manually doing it :smile:.

However, since Mattermost now disables the v3 api, I had to edit the source code to use a new driver (`mattermost-redux`).

I only implemented this for importing emoji to Mattermost, so this isn't in any kind of merging state, but I figured I may as well submit this as a PR so others can import using the v4 api or finish up the migration.